### PR TITLE
Fixed caching issue in UMDFastBindingObject::FindOrCreateExtendableItemName

### DIFF
--- a/Source/MDFastBinding/Private/MDFastBindingObject.cpp
+++ b/Source/MDFastBinding/Private/MDFastBindingObject.cpp
@@ -140,7 +140,7 @@ const FName& UMDFastBindingObject::FindOrCreateExtendableItemName(const FName& B
 
 	FName& Result = ItemNameMap.FindOrAdd(TTuple<FName, int32>(Base, Index));
 
-	if (!Result.IsValid())
+	if (Result.IsNone())
 	{
 		Result = *FString::Printf(TEXT("%s %d"), *Base.ToString(), Index);
 	}


### PR DESCRIPTION
`FName::IsValid()` is generally intended for validating whether memory corruption occurred in an `FName`, and a default-initialized `FName` satisfies this check. As a result, every call to `UMDFastBindingObject::FindOrCreateExtendableItemName` added the value "None" to the map.

Switching this to `Result.IsNone()` resolved the issue.