### PR TITLE
Apply class extension within HandleCopyTermDefaultsToDefaultObject

### DIFF
--- a/Source/MDFastBindingBlueprint/Private/BlueprintExtension/MDFastBindingWidgetBlueprintExtension.cpp
+++ b/Source/MDFastBindingBlueprint/Private/BlueprintExtension/MDFastBindingWidgetBlueprintExtension.cpp
@@ -61,21 +61,23 @@ void UMDFastBindingWidgetBlueprintExtension::HandleBeginCompilation(FWidgetBluep
 	CompilerContext = &InCreationContext;
 }
 
-void UMDFastBindingWidgetBlueprintExtension::HandleFinishCompilingClass(UWidgetBlueprintGeneratedClass* Class)
+void UMDFastBindingWidgetBlueprintExtension::HandleCopyTermDefaultsToDefaultObject(UObject* DefaultObject)
 {
-	Super::HandleFinishCompilingClass(Class);
-
-	if (CompilerContext != nullptr && DoesBlueprintOrSuperClassesHaveBindings())
+	Super::HandleCopyTermDefaultsToDefaultObject(DefaultObject);
+	
+	if (UWidgetBlueprintGeneratedClass* WidgetBPClass = Cast<UWidgetBlueprintGeneratedClass>(DefaultObject->GetClass()))
 	{
-		UMDFastBindingWidgetClassExtension* BindingClass = NewObject<UMDFastBindingWidgetClassExtension>(Class);
-		if (BindingContainer != nullptr && BindingContainer->GetBindings().Num() > 0)
+		if (CompilerContext != nullptr && DoesBlueprintOrSuperClassesHaveBindings())
 		{
-			BindingClass->SetBindingContainer(BindingContainer);
+			UMDFastBindingWidgetClassExtension* BindingClass = NewObject<UMDFastBindingWidgetClassExtension>(WidgetBPClass);
+			if (BindingContainer != nullptr && BindingContainer->GetBindings().Num() > 0)
+			{
+				BindingClass->SetBindingContainer(BindingContainer);
+			}
+		
+			// There's a chance we could perform some compile-time steps here that would improve runtime performance
+			CompilerContext->AddExtension(WidgetBPClass, BindingClass);
 		}
-
-		// There's a chance we could perform some compile-time steps here that would improve runtime performance
-
-		CompilerContext->AddExtension(Class, BindingClass);
 	}
 }
 

--- a/Source/MDFastBindingBlueprint/Public/BlueprintExtension/MDFastBindingWidgetBlueprintExtension.h
+++ b/Source/MDFastBindingBlueprint/Public/BlueprintExtension/MDFastBindingWidgetBlueprintExtension.h
@@ -35,7 +35,7 @@ public:
 
 protected:
 	virtual void HandleBeginCompilation(FWidgetBlueprintCompilerContext& InCreationContext) override;
-	virtual void HandleFinishCompilingClass(UWidgetBlueprintGeneratedClass* Class) override;
+	virtual void HandleCopyTermDefaultsToDefaultObject(UObject* DefaultObject) override;
 	virtual bool HandleValidateGeneratedClass(UWidgetBlueprintGeneratedClass* Class) override;
 	virtual void HandleEndCompilation() override;
 


### PR DESCRIPTION
We have a custom FieldNotify implementation that relies on fetching the CDO of its owning widget class in order to set up bindings based on its serialized properties. When compiling its associated widget blueprint however, it turns out that `HandleFinishCompilingClass` triggers before the CDO has had a chance to fully serialize. This causes its associated bindings to get orphaned every time the blueprint is loaded or recompiled.

Switching this over to `HandleCopyTermDefaultsToDefaultObject` resolves this issue gracefully, as it triggers at a later point during blueprint compilation.