### PR TITLE
Fixes for undefined behavior caused by dangling pointers

### DIFF
--- a/Source/MDFastBinding/Private/BindingDestinations/MDFastBindingDestination_Property.cpp
+++ b/Source/MDFastBinding/Private/BindingDestinations/MDFastBindingDestination_Property.cpp
@@ -1,6 +1,7 @@
 ﻿#include "BindingDestinations/MDFastBindingDestination_Property.h"
 
 #include "MDFastBinding.h"
+#include "MDFastBindingFieldPath.h"
 
 #define LOCTEXT_NAMESPACE "MDFastBindingDestination_Property"
 
@@ -157,9 +158,19 @@ void UMDFastBindingDestination_Property::SetFieldPath(const TArray<FFieldVariant
 	PropertyPath.BuildPath();
 }
 
-const TArray<FFieldVariant>& UMDFastBindingDestination_Property::GetFieldPath()
+TArray<FFieldVariant> UMDFastBindingDestination_Property::GetFieldPath()
 {
-	return PropertyPath.GetFieldPath();
+	const TArray<FMDFastBindingFieldPathVariant>& FieldPath = PropertyPath.GetFieldPath();
+	
+	TArray<FFieldVariant> ReturnPath;
+	ReturnPath.Reserve(FieldPath.Num());
+
+	for (const FMDFastBindingFieldPathVariant& FieldPathVariant : FieldPath)
+	{
+		ReturnPath.Add(FieldPathVariant.GetFieldVariant());
+	}
+	
+	return ReturnPath;
 }
 #endif
 

--- a/Source/MDFastBinding/Private/BindingDestinations/MDFastBindingDestination_Property.cpp
+++ b/Source/MDFastBinding/Private/BindingDestinations/MDFastBindingDestination_Property.cpp
@@ -160,17 +160,7 @@ void UMDFastBindingDestination_Property::SetFieldPath(const TArray<FFieldVariant
 
 TArray<FFieldVariant> UMDFastBindingDestination_Property::GetFieldPath()
 {
-	const TArray<FMDFastBindingFieldPathVariant>& FieldPath = PropertyPath.GetFieldPath();
-	
-	TArray<FFieldVariant> ReturnPath;
-	ReturnPath.Reserve(FieldPath.Num());
-
-	for (const FMDFastBindingFieldPathVariant& FieldPathVariant : FieldPath)
-	{
-		ReturnPath.Add(FieldPathVariant.GetFieldVariant());
-	}
-	
-	return ReturnPath;
+	return PropertyPath.GetFieldPath();
 }
 #endif
 

--- a/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Function.cpp
+++ b/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Function.cpp
@@ -92,9 +92,9 @@ void UMDFastBindingValue_Function::PopulateFunctionParam(UObject* SourceObject, 
 	bNeedsUpdate |= bDidUpdate;
 }
 
-bool UMDFastBindingValue_Function::IsFunctionValid(UFunction* Func, const FProperty* ReturnValue, const TArray<const FProperty*>& Params) const
+bool UMDFastBindingValue_Function::IsFunctionValid(UFunction* Func, const TWeakFieldPtr<const FProperty>& ReturnValue, const TArray<TWeakFieldPtr<const FProperty>>& Params) const
 {
-	return ReturnValue != nullptr;
+	return ReturnValue.IsValid();
 }
 
 void UMDFastBindingValue_Function::SetupBindingItems()

--- a/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Property.cpp
+++ b/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Property.cpp
@@ -1,5 +1,7 @@
 ﻿#include "BindingValues/MDFastBindingValue_Property.h"
 
+#include "MDFastBindingFieldPath.h"
+
 #define LOCTEXT_NAMESPACE "MDFastBindingValue_Property"
 
 namespace MDFastBindingValue_Property_Private
@@ -93,8 +95,8 @@ void UMDFastBindingValue_Property::PostInitProperties()
 
 FFieldVariant UMDFastBindingValue_Property::GetLeafField()
 {
-	const TArray<FFieldVariant>& FieldPath = PropertyPath.GetFieldPath();
-	return FieldPath.IsEmpty() ? FFieldVariant{} : FieldPath.Last();
+	const TArray<FMDFastBindingFieldPathVariant>& FieldPath = PropertyPath.GetFieldPath();
+	return FieldPath.IsEmpty() ? FFieldVariant{} : FieldPath.Last().GetFieldVariant();
 }
 
 #if WITH_EDITOR
@@ -146,9 +148,19 @@ void UMDFastBindingValue_Property::SetFieldPath(const TArray<FFieldVariant>& Pat
 	PropertyPath.BuildPath();
 }
 
-const TArray<FFieldVariant>& UMDFastBindingValue_Property::GetFieldPath()
+TArray<FFieldVariant> UMDFastBindingValue_Property::GetFieldPath()
 {
-	return PropertyPath.GetFieldPath();
+	const TArray<FMDFastBindingFieldPathVariant>& FieldPath = PropertyPath.GetFieldPath();
+	
+	TArray<FFieldVariant> ReturnPath;
+	ReturnPath.Reserve(FieldPath.Num());
+
+	for (const FMDFastBindingFieldPathVariant& FieldPathVariant : FieldPath)
+	{
+		ReturnPath.Add(FieldPathVariant.GetFieldVariant());
+	}
+	
+	return ReturnPath;
 }
 #endif
 

--- a/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Property.cpp
+++ b/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Property.cpp
@@ -95,8 +95,7 @@ void UMDFastBindingValue_Property::PostInitProperties()
 
 FFieldVariant UMDFastBindingValue_Property::GetLeafField()
 {
-	const TArray<FMDFastBindingFieldPathVariant>& FieldPath = PropertyPath.GetFieldPath();
-	return FieldPath.IsEmpty() ? FFieldVariant{} : FieldPath.Last().GetFieldVariant();
+	return PropertyPath.GetLeafField();
 }
 
 #if WITH_EDITOR
@@ -150,17 +149,7 @@ void UMDFastBindingValue_Property::SetFieldPath(const TArray<FFieldVariant>& Pat
 
 TArray<FFieldVariant> UMDFastBindingValue_Property::GetFieldPath()
 {
-	const TArray<FMDFastBindingFieldPathVariant>& FieldPath = PropertyPath.GetFieldPath();
-	
-	TArray<FFieldVariant> ReturnPath;
-	ReturnPath.Reserve(FieldPath.Num());
-
-	for (const FMDFastBindingFieldPathVariant& FieldPathVariant : FieldPath)
-	{
-		ReturnPath.Add(FieldPathVariant.GetFieldVariant());
-	}
-	
-	return ReturnPath;
+	return PropertyPath.GetFieldPath();
 }
 #endif
 

--- a/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_StaticFunction.cpp
+++ b/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_StaticFunction.cpp
@@ -12,7 +12,7 @@ UObject* UMDFastBindingValue_StaticFunction::GetFunctionOwner(UObject* SourceObj
 	return FunctionOwnerClass != nullptr ? FunctionOwnerClass.GetDefaultObject() : nullptr;
 }
 
-bool UMDFastBindingValue_StaticFunction::IsFunctionValid(UFunction* Func, const FProperty* ReturnValue, const TArray<const FProperty*>& Params) const
+bool UMDFastBindingValue_StaticFunction::IsFunctionValid(UFunction* Func, const TWeakFieldPtr<const FProperty>& ReturnValue, const TArray<TWeakFieldPtr<const FProperty>>& Params) const
 {
 	return Super::IsFunctionValid(Func, ReturnValue, Params) && Func != nullptr && Func->HasAnyFunctionFlags(FUNC_Static);
 }

--- a/Source/MDFastBinding/Private/MDFastBindingFieldPath.cpp
+++ b/Source/MDFastBinding/Private/MDFastBindingFieldPath.cpp
@@ -1,7 +1,6 @@
 ﻿#include "MDFastBindingFieldPath.h"
 
 #include "MDFastBindingHelpers.h"
-#include "UObject/WeakFieldPtr.h"
 
 FMDFastBindingFieldPath::~FMDFastBindingFieldPath()
 {
@@ -18,13 +17,13 @@ bool FMDFastBindingFieldPath::BuildPath()
 	{
 		for (const FMDFastBindingMemberReference& FieldPathMember : FieldPathMembers)
 		{
-			const FProperty* NextProp = nullptr;
+			TWeakFieldPtr<const FProperty> NextProp = nullptr;
 			if (FieldPathMember.bIsFunction)
 			{
-				const UFunction* Func = FieldPathMember.ResolveMember<UFunction>();
+				UFunction* Func = FieldPathMember.ResolveMember<UFunction>();
 				CachedPath.Add(Func);
 
-				TArray<const FProperty*> Params;
+				TArray<TWeakFieldPtr<const FProperty>> Params;
 				FMDFastBindingHelpers::SplitFunctionParamsAndReturnProp(Func, Params, NextProp);
 			}
 			else if (const FProperty* Prop = FieldPathMember.ResolveMember<FProperty>())
@@ -35,15 +34,16 @@ bool FMDFastBindingFieldPath::BuildPath()
 			else if (OwnerStruct != nullptr)
 			{
 				// FMemberReference only supports members of UObjects, so we have to manually handle UStruct members
-				NextProp = OwnerStruct->FindPropertyByName(FieldPathMember.GetMemberName());
-				CachedPath.Add(NextProp);
+				const FProperty* StructProp = OwnerStruct->FindPropertyByName(FieldPathMember.GetMemberName());
+				NextProp = StructProp;
+				CachedPath.Add(StructProp);
 			}
 
-			if (const FObjectPropertyBase* ObjectProp = CastField<const FObjectPropertyBase>(NextProp))
+			if (const FObjectPropertyBase* ObjectProp = CastField<const FObjectPropertyBase>(NextProp.Get()))
 			{
 				OwnerStruct = ObjectProp->PropertyClass;
 			}
-			else if (const FStructProperty* StructProp = CastField<const FStructProperty>(NextProp))
+			else if (const FStructProperty* StructProp = CastField<const FStructProperty>(NextProp.Get()))
 			{
 				OwnerStruct = StructProp->Struct;
 			}
@@ -67,7 +67,7 @@ bool FMDFastBindingFieldPath::BuildPath()
 	return bIsPathValid;
 }
 
-const TArray<FFieldVariant>& FMDFastBindingFieldPath::GetFieldPath()
+const TArray<FMDFastBindingFieldPathVariant>& FMDFastBindingFieldPath::GetFieldPath()
 {
 #if WITH_EDITORONLY_DATA
 	// Only cached once per frame, since the user could change the path
@@ -103,11 +103,11 @@ TTuple<const FProperty*, void*> FMDFastBindingFieldPath::ResolvePathFromRootObje
 	{
 		bool bIsOwnerAUObject = true;
 		void* LastOwner = nullptr;
-		const TArray<FFieldVariant>& Path = GetFieldPath();
+		const TArray<FMDFastBindingFieldPathVariant>& Path = GetFieldPath();
 		for (int32 i = 0; i < Path.Num() && Owner != nullptr; ++i)
 		{
-			const FFieldVariant& FieldVariant = Path[i];
-			const FProperty* OwnerProp = nullptr;
+			const FMDFastBindingFieldPathVariant& FieldVariant = Path[i];
+			TWeakFieldPtr<const FProperty> OwnerProp = nullptr;
 			LastOwner = Owner;
 
 			if (UFunction* Func = Cast<UFunction>(FieldVariant.ToUObject()))
@@ -137,7 +137,7 @@ TTuple<const FProperty*, void*> FMDFastBindingFieldPath::ResolvePathFromRootObje
 
 				OwnerUObject->ProcessEvent(Func, FuncMemory);
 
-				TArray<const FProperty*> Params;
+				TArray<TWeakFieldPtr<const FProperty>> Params;
 				FMDFastBindingHelpers::SplitFunctionParamsAndReturnProp(Func, Params, OwnerProp);
 				Owner = FuncMemory;
 			}
@@ -217,7 +217,7 @@ TTuple<const FProperty*, void*> FMDFastBindingFieldPath::ResolvePathFromRootObje
 					OutContainer = LastOwner;
 				}
 
-				return TTuple<const FProperty*, void*>{ OwnerProp, Owner };
+				return TTuple<const FProperty*, void*>{ OwnerProp.Get(), Owner };
 			}
 
 			bIsOwnerAUObject = OwnerProp != nullptr && OwnerProp->IsA(FObjectPropertyBase::StaticClass());
@@ -229,18 +229,18 @@ TTuple<const FProperty*, void*> FMDFastBindingFieldPath::ResolvePathFromRootObje
 
 const FProperty* FMDFastBindingFieldPath::GetLeafProperty()
 {
-	const TArray<FFieldVariant>& Path = GetFieldPath();
+	const TArray<FMDFastBindingFieldPathVariant>& Path = GetFieldPath();
 
 	if (Path.Num() > 0)
 	{
-		const FFieldVariant& FieldVariant = Path.Last();
+		const FMDFastBindingFieldPathVariant& FieldVariant = Path.Last();
 
 		if (const UFunction* Func = Cast<UFunction>(FieldVariant.ToUObject()))
 		{
-			const FProperty* ReturnProp = nullptr;
-			TArray<const FProperty*> Params;
+			TWeakFieldPtr<const FProperty> ReturnProp = nullptr;
+			TArray<TWeakFieldPtr<const FProperty>> Params;
 			FMDFastBindingHelpers::SplitFunctionParamsAndReturnProp(Func, Params, ReturnProp);
-			return ReturnProp;
+			return ReturnProp.Get();
 		}
 		else if (const FProperty* Prop = CastField<const FProperty>(FieldVariant.ToField()))
 		{
@@ -253,7 +253,7 @@ const FProperty* FMDFastBindingFieldPath::GetLeafProperty()
 
 bool FMDFastBindingFieldPath::IsLeafFunction()
 {
-	const TArray<FFieldVariant>& Path = GetFieldPath();
+	const TArray<FMDFastBindingFieldPathVariant>& Path = GetFieldPath();
 
 	if (Path.Num() > 0)
 	{
@@ -280,8 +280,8 @@ bool FMDFastBindingFieldPath::IsFunctionValidForPath(const UFunction& Func) cons
 		return false;
 	}
 
-	TArray<const FProperty*> Params;
-	const FProperty* ReturnProp = nullptr;
+	TArray<TWeakFieldPtr<const FProperty>> Params;
+	TWeakFieldPtr<const FProperty> ReturnProp = nullptr;
 	FMDFastBindingHelpers::SplitFunctionParamsAndReturnProp(&Func, Params, ReturnProp);
 
 	return Params.Num() == 0 && ReturnProp != nullptr;
@@ -504,12 +504,12 @@ void FMDFastBindingFieldPath::FixupFieldPath()
 				PathMember.FixUpReference(*OwnerClass);
 			}
 
-			const FProperty* NextProp = nullptr;
+			TWeakFieldPtr<const FProperty> NextProp = nullptr;
 			if (PathMember.bIsFunction)
 			{
 				const UFunction* Func = PathMember.ResolveMember<UFunction>();
 
-				TArray<const FProperty*> Params;
+				TArray<TWeakFieldPtr<const FProperty>> Params;
 				FMDFastBindingHelpers::SplitFunctionParamsAndReturnProp(Func, Params, NextProp);
 			}
 			else if (const FProperty* Prop = PathMember.ResolveMember<FProperty>())
@@ -521,11 +521,11 @@ void FMDFastBindingFieldPath::FixupFieldPath()
 				NextProp = OwnerStruct->FindPropertyByName(PathMember.GetMemberName());
 			}
 
-			if (const FObjectPropertyBase* ObjectProp = CastField<const FObjectPropertyBase>(NextProp))
+			if (const FObjectPropertyBase* ObjectProp = CastField<const FObjectPropertyBase>(NextProp.Get()))
 			{
 				OwnerStruct = ObjectProp->PropertyClass;
 			}
-			else if (const FStructProperty* StructProp = CastField<const FStructProperty>(NextProp))
+			else if (const FStructProperty* StructProp = CastField<const FStructProperty>(NextProp.Get()))
 			{
 				OwnerStruct = StructProp->Struct;
 			}

--- a/Source/MDFastBinding/Private/MDFastBindingFunctionWrapper.cpp
+++ b/Source/MDFastBinding/Private/MDFastBindingFunctionWrapper.cpp
@@ -22,6 +22,8 @@ bool FMDFastBindingFunctionWrapper::BuildFunctionData()
 		FMDFastBindingHelpers::SplitFunctionParamsAndReturnProp(FunctionPtr, Params, ReturnProp);
 	}
 
+	RefreshCachedProperties();
+
 	const bool bIsFuncValid = IsValid(FunctionPtr);
 #if WITH_EDITORONLY_DATA
 	LastFrameFunctionUpdated = bIsFuncValid ? GFrameCounter : TOptional<uint64>();
@@ -35,7 +37,7 @@ UClass* FMDFastBindingFunctionWrapper::GetFunctionOwnerClass() const
 	return OwnerClassGetter.IsBound() ? OwnerClassGetter.Execute() : nullptr;
 }
 
-const TArray<const FProperty*>& FMDFastBindingFunctionWrapper::GetParams()
+TArray<const FProperty*> FMDFastBindingFunctionWrapper::GetParams()
 {
 #if WITH_EDITORONLY_DATA
 	if (!LastFrameFunctionUpdated.IsSet() || LastFrameFunctionUpdated.GetValue() != GFrameCounter)
@@ -46,7 +48,7 @@ const TArray<const FProperty*>& FMDFastBindingFunctionWrapper::GetParams()
 		BuildFunctionData();
 	}
 
-	return Params;
+	return CachedParams;
 }
 
 const FProperty* FMDFastBindingFunctionWrapper::GetReturnProp()
@@ -60,7 +62,7 @@ const FProperty* FMDFastBindingFunctionWrapper::GetReturnProp()
 		BuildFunctionData();
 	}
 
-	return ReturnProp;
+	return CachedReturnProp;
 }
 
 UFunction* FMDFastBindingFunctionWrapper::GetFunctionPtr()
@@ -105,10 +107,10 @@ TTuple<const FProperty*, void*> FMDFastBindingFunctionWrapper::CallFunction(UObj
 
 	FunctionOwner->ProcessEvent(FunctionPtr, FunctionMemory);
 
-	if (ReturnProp != nullptr)
+	if (CachedReturnProp != nullptr)
 	{
-		void* ReturnValuePtr = static_cast<uint8*>(FunctionMemory) + ReturnProp->GetOffset_ForUFunction();
-		return TTuple<const FProperty*, void*>{ ReturnProp, ReturnValuePtr };
+		void* ReturnValuePtr = static_cast<uint8*>(FunctionMemory) + CachedReturnProp->GetOffset_ForUFunction();
+		return TTuple<const FProperty*, void*>{ CachedReturnProp, ReturnValuePtr };
 	}
 
 	return {};
@@ -124,14 +126,14 @@ FString FMDFastBindingFunctionWrapper::ToString()
 
 FString FMDFastBindingFunctionWrapper::FunctionToString(UFunction* Func)
 {
-	const FProperty* ReturnProp = nullptr;
-	TArray<const FProperty*> Params;
+	TWeakFieldPtr<const FProperty> ReturnProp = nullptr;
+	TArray<TWeakFieldPtr<const FProperty>> Params;
 	FMDFastBindingHelpers::SplitFunctionParamsAndReturnProp(Func, Params, ReturnProp);
 
 	return FunctionToString_Internal(Func, ReturnProp, Params);
 }
 
-FString FMDFastBindingFunctionWrapper::FunctionToString_Internal(UFunction* Func, const FProperty* ReturnProp, const TArray<const FProperty*>& Params)
+FString FMDFastBindingFunctionWrapper::FunctionToString_Internal(UFunction* Func, const TWeakFieldPtr<const FProperty>& ReturnProp, const TArray<TWeakFieldPtr<const FProperty>>& Params)
 {
 	if (Func == nullptr)
 	{
@@ -141,7 +143,7 @@ FString FMDFastBindingFunctionWrapper::FunctionToString_Internal(UFunction* Func
 	FString ParamString;
 	for (int32 i = 0; i < Params.Num(); ++i)
 	{
-		if (const FProperty* Param = Params[i])
+		if (const FProperty* Param = Params[i].Get())
 		{
 			if (i != 0)
 			{
@@ -152,7 +154,8 @@ FString FMDFastBindingFunctionWrapper::FunctionToString_Internal(UFunction* Func
 		}
 	}
 
-	const FString ReturnString = ReturnProp != nullptr ? FMDFastBindingHelpers::PropertyToString(*ReturnProp) : TEXT("void");
+	const FProperty* ReturnPropPtr = ReturnProp.Get(); 
+	const FString ReturnString = ReturnPropPtr != nullptr ? FMDFastBindingHelpers::PropertyToString(*ReturnPropPtr) : TEXT("void");
 
 	return FString::Printf(TEXT("%s %s(%s)"), *ReturnString, *Func->GetFName().ToString(), *ParamString);
 }
@@ -226,4 +229,19 @@ void FMDFastBindingFunctionWrapper::FixupFunctionMember()
 		// Check if FunctionMember needs to be updated with a new owner, likely due to a reparented or duplicated BP
 		FunctionMember.FixUpReference(*OwnerClass);
 	}
+}
+
+void FMDFastBindingFunctionWrapper::RefreshCachedProperties()
+{
+	CachedParams.Reset(Params.Num());
+	
+	for (const TWeakFieldPtr<const FProperty>& WeakParam : Params)
+	{
+		if (const FProperty* Param = WeakParam.Get())
+		{
+			CachedParams.Add(Param);
+		}
+	}
+
+	CachedReturnProp = ReturnProp.Get();
 }

--- a/Source/MDFastBinding/Private/MDFastBindingFunctionWrapper.cpp
+++ b/Source/MDFastBinding/Private/MDFastBindingFunctionWrapper.cpp
@@ -39,11 +39,7 @@ UClass* FMDFastBindingFunctionWrapper::GetFunctionOwnerClass() const
 
 TArray<const FProperty*> FMDFastBindingFunctionWrapper::GetParams()
 {
-#if WITH_EDITORONLY_DATA
-	if (!LastFrameFunctionUpdated.IsSet() || LastFrameFunctionUpdated.GetValue() != GFrameCounter || FunctionMember.ResolveMember<UFunction>() != FunctionPtr)
-#else
-	if (FunctionPtr == nullptr)
-#endif
+	if (ShouldRebuildFunctionData())
 	{
 		BuildFunctionData();
 	}
@@ -53,11 +49,7 @@ TArray<const FProperty*> FMDFastBindingFunctionWrapper::GetParams()
 
 const FProperty* FMDFastBindingFunctionWrapper::GetReturnProp()
 {
-#if WITH_EDITORONLY_DATA
-	if (!LastFrameFunctionUpdated.IsSet() || LastFrameFunctionUpdated.GetValue() != GFrameCounter)
-#else
-	if (FunctionPtr == nullptr)
-#endif
+	if (ShouldRebuildFunctionData())
 	{
 		BuildFunctionData();
 	}
@@ -67,11 +59,7 @@ const FProperty* FMDFastBindingFunctionWrapper::GetReturnProp()
 
 UFunction* FMDFastBindingFunctionWrapper::GetFunctionPtr()
 {
-#if WITH_EDITORONLY_DATA
-	if (!LastFrameFunctionUpdated.IsSet() || LastFrameFunctionUpdated.GetValue() != GFrameCounter)
-#else
-	if (FunctionPtr == nullptr)
-#endif
+	if (ShouldRebuildFunctionData())
 	{
 		BuildFunctionData();
 	}
@@ -81,11 +69,7 @@ UFunction* FMDFastBindingFunctionWrapper::GetFunctionPtr()
 
 TTuple<const FProperty*, void*> FMDFastBindingFunctionWrapper::CallFunction(UObject* SourceObject)
 {
-#if WITH_EDITORONLY_DATA
-	if (!LastFrameFunctionUpdated.IsSet() || LastFrameFunctionUpdated.GetValue() != GFrameCounter)
-#else
-	if (FunctionPtr == nullptr)
-#endif
+	if (ShouldRebuildFunctionData())
 	{
 		BuildFunctionData();
 	}
@@ -176,6 +160,17 @@ void FMDFastBindingFunctionWrapper::OnVariableRenamed(UClass* VariableClass, con
 	}
 }
 #endif
+
+bool FMDFastBindingFunctionWrapper::ShouldRebuildFunctionData() const
+{
+#if WITH_EDITORONLY_DATA
+	return !LastFrameFunctionUpdated.IsSet()
+	|| LastFrameFunctionUpdated.GetValue() != GFrameCounter
+	|| FunctionMember.ResolveMember<UFunction>() != FunctionPtr;
+#else
+	return FunctionPtr == nullptr;
+#endif
+}
 
 UObject* FMDFastBindingFunctionWrapper::GetFunctionOwner(UObject* SourceObject) const
 {

--- a/Source/MDFastBinding/Private/MDFastBindingFunctionWrapper.cpp
+++ b/Source/MDFastBinding/Private/MDFastBindingFunctionWrapper.cpp
@@ -40,7 +40,7 @@ UClass* FMDFastBindingFunctionWrapper::GetFunctionOwnerClass() const
 TArray<const FProperty*> FMDFastBindingFunctionWrapper::GetParams()
 {
 #if WITH_EDITORONLY_DATA
-	if (!LastFrameFunctionUpdated.IsSet() || LastFrameFunctionUpdated.GetValue() != GFrameCounter)
+	if (!LastFrameFunctionUpdated.IsSet() || LastFrameFunctionUpdated.GetValue() != GFrameCounter || FunctionMember.ResolveMember<UFunction>() != FunctionPtr)
 #else
 	if (FunctionPtr == nullptr)
 #endif

--- a/Source/MDFastBinding/Private/MDFastBindingFunctionWrapper.cpp
+++ b/Source/MDFastBinding/Private/MDFastBindingFunctionWrapper.cpp
@@ -82,7 +82,7 @@ UFunction* FMDFastBindingFunctionWrapper::GetFunctionPtr()
 TTuple<const FProperty*, void*> FMDFastBindingFunctionWrapper::CallFunction(UObject* SourceObject)
 {
 #if WITH_EDITORONLY_DATA
-	if (!LastFrameFunctionUpdated.IsSet() || LastFrameFunctionUpdated.GetValue() != GFrameCounter || FunctionMember.ResolveMember<UFunction>() != FunctionPtr)
+	if (!LastFrameFunctionUpdated.IsSet() || LastFrameFunctionUpdated.GetValue() != GFrameCounter)
 #else
 	if (FunctionPtr == nullptr)
 #endif

--- a/Source/MDFastBinding/Private/MDFastBindingFunctionWrapper.cpp
+++ b/Source/MDFastBinding/Private/MDFastBindingFunctionWrapper.cpp
@@ -82,7 +82,7 @@ UFunction* FMDFastBindingFunctionWrapper::GetFunctionPtr()
 TTuple<const FProperty*, void*> FMDFastBindingFunctionWrapper::CallFunction(UObject* SourceObject)
 {
 #if WITH_EDITORONLY_DATA
-	if (!LastFrameFunctionUpdated.IsSet() || LastFrameFunctionUpdated.GetValue() != GFrameCounter)
+	if (!LastFrameFunctionUpdated.IsSet() || LastFrameFunctionUpdated.GetValue() != GFrameCounter || FunctionMember.ResolveMember<UFunction>() != FunctionPtr)
 #else
 	if (FunctionPtr == nullptr)
 #endif

--- a/Source/MDFastBinding/Private/MDFastBindingHelpers.cpp
+++ b/Source/MDFastBinding/Private/MDFastBindingHelpers.cpp
@@ -27,11 +27,11 @@ void FMDFastBindingHelpers::GetFunctionParamProps(const UFunction* Func, TArray<
 	}
 }
 
-void FMDFastBindingHelpers::SplitFunctionParamsAndReturnProp(const UFunction* Func, TArray<const FProperty*>& OutParams,
-                                                             const FProperty*& OutReturnProp)
+void FMDFastBindingHelpers::SplitFunctionParamsAndReturnProp(const UFunction* Func, TArray<TWeakFieldPtr<const FProperty>>& OutParams,
+                                                             TWeakFieldPtr<const FProperty>& OutReturnProp)
 {
 	OutParams.Empty();
-	OutReturnProp = nullptr;
+	OutReturnProp.Reset();
 
 	if (Func != nullptr)
 	{
@@ -45,7 +45,7 @@ void FMDFastBindingHelpers::SplitFunctionParamsAndReturnProp(const UFunction* Fu
 				{
 					const bool bIsReturnParam = Param->HasAnyPropertyFlags(CPF_ReturnParm)
 						|| (Param->HasAnyPropertyFlags(CPF_OutParm) && !Param->HasAnyPropertyFlags(CPF_ReferenceParm));
-					if (Param != OutReturnProp && !bIsReturnParam)
+					if (Param != OutReturnProp.Get() && !bIsReturnParam)
 					{
 						OutParams.Add(Param);
 					}

--- a/Source/MDFastBinding/Public/BindingDestinations/MDFastBindingDestination_Property.h
+++ b/Source/MDFastBinding/Public/BindingDestinations/MDFastBindingDestination_Property.h
@@ -21,7 +21,7 @@ public:
 	virtual void OnVariableRenamed(UClass* VariableClass, const FName& OldVariableName, const FName& NewVariableName) override;
 
 	void SetFieldPath(const TArray<FFieldVariant>& Path);
-	const TArray<FFieldVariant>& GetFieldPath();
+	TArray<FFieldVariant> GetFieldPath();
 #endif
 
 #if WITH_EDITORONLY_DATA

--- a/Source/MDFastBinding/Public/BindingValues/MDFastBindingValue_Function.h
+++ b/Source/MDFastBinding/Public/BindingValues/MDFastBindingValue_Function.h
@@ -2,6 +2,7 @@
 
 #include "MDFastBindingFunctionWrapper.h"
 #include "MDFastBindingValueBase.h"
+#include "UObject/WeakFieldPtr.h"
 #include "MDFastBindingValue_Function.generated.h"
 
 /**
@@ -36,7 +37,7 @@ protected:
 	virtual UObject* GetFunctionOwner(UObject* SourceObject);
 	virtual UClass* GetFunctionOwnerClass();
 	virtual void PopulateFunctionParam(UObject* SourceObject, const FProperty* Param, void* ValuePtr);
-	virtual bool IsFunctionValid(UFunction* Func, const FProperty* ReturnValue, const TArray<const FProperty*>& Params) const;
+	virtual bool IsFunctionValid(UFunction* Func, const TWeakFieldPtr<const FProperty>& ReturnValue, const TArray<TWeakFieldPtr<const FProperty>>& Params) const;
 
 	virtual void SetupBindingItems() override;
 

--- a/Source/MDFastBinding/Public/BindingValues/MDFastBindingValue_Property.h
+++ b/Source/MDFastBinding/Public/BindingValues/MDFastBindingValue_Property.h
@@ -27,7 +27,7 @@ public:
 	virtual void OnVariableRenamed(UClass* VariableClass, const FName& OldVariableName, const FName& NewVariableName) override;
 
 	void SetFieldPath(const TArray<FFieldVariant>& Path);
-	const TArray<FFieldVariant>& GetFieldPath();
+	TArray<FFieldVariant> GetFieldPath();
 #endif
 
 protected:

--- a/Source/MDFastBinding/Public/BindingValues/MDFastBindingValue_StaticFunction.h
+++ b/Source/MDFastBinding/Public/BindingValues/MDFastBindingValue_StaticFunction.h
@@ -21,7 +21,7 @@ public:
 protected:
 	virtual UObject* GetFunctionOwner(UObject* SourceObject) override;
 	virtual UClass* GetFunctionOwnerClass() override { return FunctionOwnerClass; }
-	virtual bool IsFunctionValid(UFunction* Func, const FProperty* ReturnValue, const TArray<const FProperty*>& Params) const override;
+	virtual bool IsFunctionValid(UFunction* Func, const TWeakFieldPtr<const FProperty>& ReturnValue, const TArray<TWeakFieldPtr<const FProperty>>& Params) const override;
 
 	UPROPERTY(EditDefaultsOnly, Category = "Binding")
 	TSubclassOf<UObject> FunctionOwnerClass;

--- a/Source/MDFastBinding/Public/MDFastBindingFieldPath.h
+++ b/Source/MDFastBinding/Public/MDFastBindingFieldPath.h
@@ -10,6 +10,45 @@ DECLARE_DELEGATE_RetVal_OneParam(UObject*, FMDGetFieldPathOwner, UObject*);
 DECLARE_DELEGATE_RetVal(UStruct*, FMDGetFieldPathOwnerStruct);
 DECLARE_DELEGATE_RetVal_OneParam(bool, FMDFilterFieldPathField, const FFieldVariant&);
 
+class FMDFastBindingFieldPathVariant
+{
+public:
+	FMDFastBindingFieldPathVariant(const FField* InField)
+		: FieldVariant(InField)
+	{
+		Field = InField;
+	}
+	
+	FMDFastBindingFieldPathVariant(UObject* InObject)
+	: FieldVariant(InObject)
+	{
+		Object = InObject;
+	}
+
+	bool IsUObject() const
+	{
+		return Object.IsValid();
+	}
+	
+	FField* ToField() const
+	{
+		return Field.Get();
+	}
+
+	UObject* ToUObject() const
+	{
+		return Object.Get();
+	}
+
+	const FFieldVariant& GetFieldVariant() const { return FieldVariant; }
+
+private:
+	TWeakFieldPtr<FField> Field;
+	TWeakObjectPtr<UObject> Object;
+
+	FFieldVariant FieldVariant;
+};
+
 /**
  *
  */
@@ -22,7 +61,7 @@ public:
 	~FMDFastBindingFieldPath();
 
 	bool BuildPath();
-	const TArray<FFieldVariant>& GetFieldPath();
+	const TArray<FMDFastBindingFieldPathVariant>& GetFieldPath();
 
 	// Returns a tuple containing the leaf property in the path (or return value property if a function) and a pointer to the value,
 	// with an optional out param to retrieve the container that holds the leaf property
@@ -76,7 +115,7 @@ private:
 	TOptional<uint64> LastFrameUpdatedPath;
 #endif
 
-	TArray<FFieldVariant> CachedPath;
+	TArray<FMDFastBindingFieldPathVariant> CachedPath;
 	TMap<TWeakObjectPtr<const UFunction>, void*> FunctionMemory;
 	TMap<TWeakFieldPtr<FProperty>, void*> PropertyMemory;
 };

--- a/Source/MDFastBinding/Public/MDFastBindingFieldPath.h
+++ b/Source/MDFastBinding/Public/MDFastBindingFieldPath.h
@@ -10,6 +10,7 @@ DECLARE_DELEGATE_RetVal_OneParam(UObject*, FMDGetFieldPathOwner, UObject*);
 DECLARE_DELEGATE_RetVal(UStruct*, FMDGetFieldPathOwnerStruct);
 DECLARE_DELEGATE_RetVal_OneParam(bool, FMDFilterFieldPathField, const FFieldVariant&);
 
+// Wraps FFieldVariant to weakly hold the field
 class FMDFastBindingFieldPathVariant
 {
 public:
@@ -20,7 +21,7 @@ public:
 	}
 	
 	FMDFastBindingFieldPathVariant(UObject* InObject)
-	: FieldVariant(InObject)
+		: FieldVariant(InObject)
 	{
 		Object = InObject;
 	}

--- a/Source/MDFastBinding/Public/MDFastBindingFunctionWrapper.h
+++ b/Source/MDFastBinding/Public/MDFastBindingFunctionWrapper.h
@@ -1,13 +1,14 @@
 ﻿#pragma once
 
 #include "MDFastBindingMemberReference.h"
+#include "UObject/WeakFieldPtr.h"
 
 #include "MDFastBindingFunctionWrapper.generated.h"
 
 DECLARE_DELEGATE_RetVal_OneParam(UObject*, FMDGetFunctionOwner, UObject*);
 DECLARE_DELEGATE_RetVal(UClass*, FMDGetFunctionOwnerClass);
 DECLARE_DELEGATE_ThreeParams(FMDPopulateFunctionParam, UObject*, const FProperty*, void*);
-DECLARE_DELEGATE_RetVal_ThreeParams(bool, FMDFunctionFilter, UFunction*, const FProperty*, const TArray<const FProperty*>&);
+DECLARE_DELEGATE_RetVal_ThreeParams(bool, FMDFunctionFilter, UFunction*, const TWeakFieldPtr<const FProperty>&, const TArray<TWeakFieldPtr<const FProperty>>&);
 DECLARE_DELEGATE_RetVal(bool, FMDShouldCallFunction)
 
 /**
@@ -25,7 +26,7 @@ public:
 
 	UClass* GetFunctionOwnerClass() const;
 
-	const TArray<const FProperty*>& GetParams();
+	TArray<const FProperty*> GetParams();
 
 	const FProperty* GetReturnProp();
 
@@ -40,7 +41,7 @@ public:
 
 	static FString FunctionToString(UFunction* Func);
 
-	static FString FunctionToString_Internal(UFunction* Func, const FProperty* ReturnProp, const TArray<const FProperty*>& Params);
+	static FString FunctionToString_Internal(UFunction* Func, const TWeakFieldPtr<const FProperty>& ReturnProp, const TArray<TWeakFieldPtr<const FProperty>>& Params);
 #endif
 
 #if WITH_EDITOR
@@ -69,9 +70,11 @@ private:
 	TOptional<uint64> LastFrameFunctionUpdated;
 #endif
 
-	TArray<const FProperty*> Params;
+	TArray<TWeakFieldPtr<const FProperty>> Params;
+	TArray<const FProperty*> CachedParams;
 
-	const FProperty* ReturnProp = nullptr;
+	TWeakFieldPtr<const FProperty> ReturnProp = nullptr;
+	const FProperty* CachedReturnProp = nullptr;
 
 	void* FunctionMemory = nullptr;
 	UObject* GetFunctionOwner(UObject* SourceObject) const;
@@ -79,4 +82,5 @@ private:
 	void PopulateParams(UObject* SourceObject);
 
 	void FixupFunctionMember();
+	void RefreshCachedProperties();
 };

--- a/Source/MDFastBinding/Public/MDFastBindingFunctionWrapper.h
+++ b/Source/MDFastBinding/Public/MDFastBindingFunctionWrapper.h
@@ -66,6 +66,8 @@ private:
 	UPROPERTY(Transient)
 	TObjectPtr<UFunction> FunctionPtr = nullptr;
 
+	bool ShouldRebuildFunctionData() const;
+	
 #if WITH_EDITORONLY_DATA
 	TOptional<uint64> LastFrameFunctionUpdated;
 #endif

--- a/Source/MDFastBinding/Public/MDFastBindingHelpers.h
+++ b/Source/MDFastBinding/Public/MDFastBindingHelpers.h
@@ -2,6 +2,7 @@
 
 #include "Containers/Array.h"
 #include "Containers/UnrealString.h"
+#include "UObject/WeakFieldPtr.h"
 
 
 class FProperty;
@@ -12,7 +13,7 @@ class MDFASTBINDING_API FMDFastBindingHelpers
 {
 public:
 	static void GetFunctionParamProps(const UFunction* Func, TArray<const FProperty*>& OutParams);
-	static void SplitFunctionParamsAndReturnProp(const UFunction* Func, TArray<const FProperty*>& OutParams, const FProperty*& OutReturnProp);
+	static void SplitFunctionParamsAndReturnProp(const UFunction* Func, TArray<TWeakFieldPtr<const FProperty>>& OutParams, TWeakFieldPtr<const FProperty>& OutReturnProp);
 
 	static FString PropertyToString(const FProperty& Prop);
 

--- a/Source/MDFastBindingBlueprint/Private/BlueprintExtension/MDFastBindingWidgetBlueprintExtension.cpp
+++ b/Source/MDFastBindingBlueprint/Private/BlueprintExtension/MDFastBindingWidgetBlueprintExtension.cpp
@@ -66,7 +66,7 @@ void UMDFastBindingWidgetBlueprintExtension::HandleCopyTermDefaultsToDefaultObje
 			CompilerContext->AddExtension(WidgetBPClass, BindingClass);
 
 			// The blueprint has been fully recompiled here, we need to update the binding graphs
-			RefreshPinnedGraphs();
+			PopulatePinnedGraphs();
 		}
 	}
 }
@@ -99,7 +99,7 @@ void UMDFastBindingWidgetBlueprintExtension::HandleEndCompilation()
 		{
 			if (WidgetBPClass->GetExtension<UMDFastBindingWidgetClassExtension>() != nullptr)
 			{
-				RefreshPinnedGraphs();
+				PopulatePinnedGraphs();
 			}
 		}
 
@@ -107,7 +107,7 @@ void UMDFastBindingWidgetBlueprintExtension::HandleEndCompilation()
 	}
 }
 
-void UMDFastBindingWidgetBlueprintExtension::RefreshPinnedGraphs()
+void UMDFastBindingWidgetBlueprintExtension::PopulatePinnedGraphs()
 {
 	if (PinnedGraphs.IsEmpty() && BindingContainer != nullptr)
 	{	

--- a/Source/MDFastBindingBlueprint/Private/BlueprintExtension/MDFastBindingWidgetBlueprintExtension.cpp
+++ b/Source/MDFastBindingBlueprint/Private/BlueprintExtension/MDFastBindingWidgetBlueprintExtension.cpp
@@ -35,19 +35,6 @@ void UMDFastBindingWidgetBlueprintExtension::GetAllGraphs(TArray<UEdGraph*>& Gra
 	Super::GetAllGraphs(Graphs);
 #endif
 
-	// Since we don't serialize the binding graphs, we need to generate them on the fly
-	if (PinnedGraphs.IsEmpty() && BindingContainer != nullptr)
-	{
-		for (UMDFastBindingInstance* BindingInstance : BindingContainer->GetBindings())
-		{
-			const FString GraphName = FString::Printf(TEXT("FastBinding: %s"), *BindingInstance->GetBindingDisplayName().ToString());
-			UMDFastBindingGraph* GraphObj = NewObject<UMDFastBindingGraph>(GetWidgetBlueprint(), FName(*GraphName), RF_Transient);
-			GraphObj->Schema = UMDFastBindingGraphSchema::StaticClass();
-			GraphObj->SetBinding(BindingInstance);
-			PinnedGraphs.Add(GraphObj);
-		}
-	}
-
 	Graphs.Append(PinnedGraphs);
 }
 #endif
@@ -77,6 +64,9 @@ void UMDFastBindingWidgetBlueprintExtension::HandleCopyTermDefaultsToDefaultObje
 		
 			// There's a chance we could perform some compile-time steps here that would improve runtime performance
 			CompilerContext->AddExtension(WidgetBPClass, BindingClass);
+
+			// The blueprint has been fully recompiled here, we need to update the binding graphs
+			RefreshPinnedGraphs();
 		}
 	}
 }
@@ -101,7 +91,36 @@ void UMDFastBindingWidgetBlueprintExtension::HandleEndCompilation()
 {
 	Super::HandleEndCompilation();
 
-	CompilerContext = nullptr;
+	if (CompilerContext)
+	{
+		// If this class already has the class extension serialized, it had already been saved prior
+		// There's a chance it's being freshly loaded here so we need to generate the binding graphs
+		if (UWidgetBlueprintGeneratedClass* WidgetBPClass = Cast<UWidgetBlueprintGeneratedClass>(CompilerContext->NewClass))
+		{
+			if (WidgetBPClass->GetExtension<UMDFastBindingWidgetClassExtension>() != nullptr)
+			{
+				RefreshPinnedGraphs();
+			}
+		}
+
+		CompilerContext = nullptr;
+	}
+}
+
+void UMDFastBindingWidgetBlueprintExtension::RefreshPinnedGraphs()
+{
+	if (PinnedGraphs.IsEmpty() && BindingContainer != nullptr)
+	{	
+		// Since we don't serialize the binding graphs, we need to generate them on the fly
+		for (UMDFastBindingInstance* BindingInstance : BindingContainer->GetBindings())
+		{
+			const FString GraphName = FString::Printf(TEXT("FastBinding: %s"), *BindingInstance->GetBindingDisplayName().ToString());
+			UMDFastBindingGraph* GraphObj = NewObject<UMDFastBindingGraph>(GetWidgetBlueprint(), FName(*GraphName), RF_Transient);
+			GraphObj->Schema = UMDFastBindingGraphSchema::StaticClass();
+			GraphObj->SetBinding(BindingInstance);
+			PinnedGraphs.Add(GraphObj);
+		}
+	}
 }
 
 UClass* UMDFastBindingWidgetBlueprintExtension::GetBindingOwnerClass() const

--- a/Source/MDFastBindingBlueprint/Public/BlueprintExtension/MDFastBindingWidgetBlueprintExtension.h
+++ b/Source/MDFastBindingBlueprint/Public/BlueprintExtension/MDFastBindingWidgetBlueprintExtension.h
@@ -45,7 +45,8 @@ protected:
 private:
 	// Temporary graphs that are pinned for use with in the diff tool
 	UPROPERTY(Transient)
-	mutable TArray<TObjectPtr<class UMDFastBindingGraph>> PinnedGraphs;
+	TArray<TObjectPtr<class UMDFastBindingGraph>> PinnedGraphs;
+	void RefreshPinnedGraphs();
 
 	FWidgetBlueprintCompilerContext* CompilerContext = nullptr;
 };

--- a/Source/MDFastBindingBlueprint/Public/BlueprintExtension/MDFastBindingWidgetBlueprintExtension.h
+++ b/Source/MDFastBindingBlueprint/Public/BlueprintExtension/MDFastBindingWidgetBlueprintExtension.h
@@ -46,7 +46,7 @@ private:
 	// Temporary graphs that are pinned for use with in the diff tool
 	UPROPERTY(Transient)
 	TArray<TObjectPtr<class UMDFastBindingGraph>> PinnedGraphs;
-	void RefreshPinnedGraphs();
+	void PopulatePinnedGraphs();
 
 	FWidgetBlueprintCompilerContext* CompilerContext = nullptr;
 };

--- a/Source/MDFastBindingEditor/Private/Customizations/MDFastBindingFunctionWrapperCustomization.cpp
+++ b/Source/MDFastBindingEditor/Private/Customizations/MDFastBindingFunctionWrapperCustomization.cpp
@@ -4,6 +4,7 @@
 #include "Framework/MultiBox/MultiBoxBuilder.h"
 #include "Kismet2/BlueprintEditorUtils.h"
 #include "MDFastBindingHelpers.h"
+#include "UObject/WeakFieldPtr.h"
 #include "Widgets/Images/SImage.h"
 #include "Widgets/Input/SComboButton.h"
 #include "Widgets/Layout/SBox.h"
@@ -109,13 +110,13 @@ TSharedRef<SWidget> FMDFastBindingFunctionWrapperCustomization::BuildFunctionWid
 			.ToolTipText(LOCTEXT("NullFunctionTooltip", "Clear the selection"));
 	}
 
-	const FProperty* ReturnProp = nullptr;
-	TArray<const FProperty*> Params;
+	TWeakFieldPtr<const FProperty> ReturnProp = nullptr;
+	TArray<TWeakFieldPtr<const FProperty>> Params;
 	FMDFastBindingHelpers::SplitFunctionParamsAndReturnProp(Function, Params, ReturnProp);
 
 	const UEdGraphSchema_K2* Schema = GetDefault<UEdGraphSchema_K2>();
 	FEdGraphPinType PinType;
-	Schema->ConvertPropertyToPinType(ReturnProp, PinType);
+	Schema->ConvertPropertyToPinType(ReturnProp.Get(), PinType);
 
 	return SNew(SHorizontalBox)
 		+SHorizontalBox::Slot()
@@ -158,8 +159,8 @@ void FMDFastBindingFunctionWrapperCustomization::GatherPossibleFunctions()
 				{
 					if (FunctionWrapper->FunctionFilter.IsBound())
 					{
-						const FProperty* ReturnProp = nullptr;
-						TArray<const FProperty*> Params;
+						TWeakFieldPtr<const FProperty> ReturnProp = nullptr;
+						TArray<TWeakFieldPtr<const FProperty>> Params;
 						FMDFastBindingHelpers::SplitFunctionParamsAndReturnProp(*It, Params, ReturnProp);
 						if (!FunctionWrapper->FunctionFilter.Execute(*It, ReturnProp, Params))
 						{


### PR DESCRIPTION
We currently have a bunch of undefined behavior stemming from unmanaged `FProperty*` pointers going stale and left in a dangling state. This behavior would generally occur during contexts that triggered a blueprint reload/recompilation, such as:

- Compiling a widget blueprint with bindings
- Duplicating an existing widget blueprint asset with bindings
- Opening the blueprint diff tool on a widget blueprint with bindings

These changes primarily update a bunch of the plugin code to rely more on `TWeakFieldPtr<>` for stability, along with introducing various other fixes to mitigate the regressions that arose from that change (instead of invoking undefined behavior).

Fixes #37 