### PR TITLE
Fixed 'open binding' operations for the property binding extension

### DIFF
--- a/Source/MDFastBindingEditor/Private/Customizations/MDFastBindingPropertyBindingExtension.cpp
+++ b/Source/MDFastBindingEditor/Private/Customizations/MDFastBindingPropertyBindingExtension.cpp
@@ -141,7 +141,7 @@ namespace MDFastBindingPropertyBinding
 
 		GEditor->GetEditorSubsystem<UStatusBarSubsystem>()->TryToggleDrawer(FMDFastBindingEditorSummoner::DrawerId);
 	}
-	
+
 	static void CreateBinding(const UWidgetBlueprint* WidgetBlueprint, const UWidget* Widget, const FProperty* Property)
 	{
 		UMDFastBindingContainer* Container = RequestBindingContainer(const_cast<UWidgetBlueprint*>(WidgetBlueprint));

--- a/Source/MDFastBindingEditor/Private/Customizations/MDFastBindingPropertyBindingExtension.cpp
+++ b/Source/MDFastBindingEditor/Private/Customizations/MDFastBindingPropertyBindingExtension.cpp
@@ -10,7 +10,6 @@
 #include "Framework/MultiBox/MultiBoxBuilder.h"
 #include "Kismet2/BlueprintEditorUtils.h"
 #include "MDFastBindingContainer.h"
-#include "MDFastBindingEditorModule.h"
 #include "MDFastBindingEditorStyle.h"
 #include "MDFastBindingInstance.h"
 #include "Misc/DataValidation.h"
@@ -130,22 +129,19 @@ namespace MDFastBindingPropertyBinding
 
 	static void OpenBinding(UWidgetBlueprint* WidgetBlueprint, UMDFastBindingInstance* Binding)
 	{
-		FMDFastBindingEditorModule::OpenBindingEditor(WidgetBlueprint);
-		
 		if (IAssetEditorInstance* AssetEditorInstance = GEditor->GetEditorSubsystem<UAssetEditorSubsystem>()->FindEditorForAsset(WidgetBlueprint, false))
 		{
-			const TSharedPtr<FTabManager> TabManager = AssetEditorInstance->GetAssociatedTabManager();
-			if (TabManager.IsValid() && TabManager->HasTabSpawner(FMDFastBindingEditorSummoner::TabId))
+			FWidgetBlueprintEditor* WidgetBPEditor = static_cast<FWidgetBlueprintEditor*>(AssetEditorInstance);
+			const TSharedPtr<SMDFastBindingEditorWidget> BindingEditor = StaticCastSharedPtr<SMDFastBindingEditorWidget>(WidgetBPEditor->GetExternalEditorWidget(FMDFastBindingEditorSummoner::DrawerId));
+			if (BindingEditor.IsValid())
 			{
-				if (const TSharedPtr<SDockTab> Tab = TabManager->FindExistingLiveTab(FMDFastBindingEditorSummoner::TabId))
-				{
-					const TSharedPtr<SMDFastBindingEditorWidget> BindingEditorWidget = StaticCastSharedRef<SMDFastBindingEditorWidget>(Tab->GetContent());
-					BindingEditorWidget->SelectBinding(Binding);
-				}
+				BindingEditor->SelectBinding(Binding);
 			}
 		}
-	}
 
+		GEditor->GetEditorSubsystem<UStatusBarSubsystem>()->TryToggleDrawer(FMDFastBindingEditorSummoner::DrawerId);
+	}
+	
 	static void CreateBinding(const UWidgetBlueprint* WidgetBlueprint, const UWidget* Widget, const FProperty* Property)
 	{
 		UMDFastBindingContainer* Container = RequestBindingContainer(const_cast<UWidgetBlueprint*>(WidgetBlueprint));

--- a/Source/MDFastBindingEditor/Private/MDFastBindingEditorModule.cpp
+++ b/Source/MDFastBindingEditor/Private/MDFastBindingEditorModule.cpp
@@ -129,7 +129,7 @@ TSharedRef<FExtender> FMDFastBindingEditorModule::CheckAddBindingEditorToolbarBu
 void FMDFastBindingEditorModule::AddBindingEditorToolbarButtons(FToolBarBuilder& ToolBarBuilder, TWeakObjectPtr<UObject> EditorObject) const
 {
 	ToolBarBuilder.AddToolBarButton(
-		FUIAction(FExecuteAction::CreateRaw(this, &FMDFastBindingEditorModule::OpenBindingEditor, EditorObject))
+		FUIAction(FExecuteAction::CreateStatic(&FMDFastBindingEditorModule::OpenBindingEditor, EditorObject))
 		, NAME_None
 		, LOCTEXT("BindingEditorButtonLabel", "Binding Editor")
 		, LOCTEXT("BindingEditorButtonLabelTooltip", "Opens the binding editor for this asset")
@@ -156,9 +156,9 @@ void FMDFastBindingEditorModule::AddBindingEditorToolbarButtons(FToolBarBuilder&
 	}
 }
 
-void FMDFastBindingEditorModule::OpenBindingEditor(TWeakObjectPtr<UObject> EditorObject) const
+void FMDFastBindingEditorModule::OpenBindingEditor(TWeakObjectPtr<UObject> EditorObject)
 {
-	UObject* Object = EditorObject.Get();
+	const UObject* Object = EditorObject.Get();
 	if (Object == nullptr)
 	{
 		return;

--- a/Source/MDFastBindingEditor/Public/MDFastBindingEditorModule.h
+++ b/Source/MDFastBindingEditor/Public/MDFastBindingEditorModule.h
@@ -36,7 +36,7 @@ public:
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
 
-	void OpenBindingEditor(TWeakObjectPtr<UObject> EditorObject) const;
+	static void OpenBindingEditor(TWeakObjectPtr<UObject> EditorObject);
 
 private:
 	TSharedRef<FExtender> CheckAddBindingEditorToolbarButtons(const TSharedRef<FUICommandList> Commands, const TArray<UObject*> Objects) const;


### PR DESCRIPTION
- Fixed a crash in CreateBinding where a binding item value was being set to a destination node that was not yet built
- Updated OpenBinding such that it's able to open the binding editor and focus the proper binding item