### PR TITLE
Fixed function/property nodes returning incorrect owners

### DIFF
--- a/Source/MDFastBinding/Private/BindingDestinations/MDFastBindingDestination_Function.cpp
+++ b/Source/MDFastBinding/Private/BindingDestinations/MDFastBindingDestination_Function.cpp
@@ -27,9 +27,15 @@ UObject* UMDFastBindingDestination_Function::GetFunctionOwner(UObject* SourceObj
 	bool bDidUpdate = false;
 	const TTuple<const FProperty*, void*> FunctionOwner = GetBindingItemValue(SourceObject, MDFastBindingDestination_Function_Private::FunctionOwnerName, bDidUpdate);
 	bNeedsUpdate |= bDidUpdate;
+
 	if (FunctionOwner.Value != nullptr)
 	{
 		return *static_cast<UObject**>(FunctionOwner.Value);
+	}
+	else if (FunctionOwner.Key != nullptr)
+	{
+		// null value, but key is valid so it failed to get a value, just return null as the owner
+		return nullptr;
 	}
 
 	return SourceObject;

--- a/Source/MDFastBinding/Private/BindingDestinations/MDFastBindingDestination_Property.cpp
+++ b/Source/MDFastBinding/Private/BindingDestinations/MDFastBindingDestination_Property.cpp
@@ -62,15 +62,16 @@ UObject* UMDFastBindingDestination_Property::GetPropertyOwner(UObject* SourceObj
 {
 	bool bDidUpdate = false;
 	const TTuple<const FProperty*, void*> PathRoot = GetBindingItemValue(SourceObject, MDFastBindingDestination_Property_Private::PathRootName, bDidUpdate);
-
 	bNeedsUpdate = bDidUpdate;
 
 	if (PathRoot.Value != nullptr)
 	{
-		if (UObject* Owner = *static_cast<UObject**>(PathRoot.Value))
-		{
-			return Owner;
-		}
+		return *static_cast<UObject**>(PathRoot.Value);
+	}
+	else if (PathRoot.Key != nullptr)
+	{
+		// null value, but key is valid so it failed to get a value, just return null as the owner
+		return nullptr;
 	}
 
 	return SourceObject;

--- a/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Function.cpp
+++ b/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Function.cpp
@@ -65,6 +65,11 @@ UObject* UMDFastBindingValue_Function::GetFunctionOwner(UObject* SourceObject)
 	{
 		return *static_cast<UObject**>(FunctionOwner.Value);
 	}
+	else if (FunctionOwner.Key != nullptr)
+	{
+		// null value, but key is valid so it failed to get a value, just return null as the owner
+		return nullptr;
+	}
 
 	return SourceObject;
 }


### PR DESCRIPTION
This change fixes a crash issue where a binding was trying to call a function on the wrong owning object type (ie. the owning widget instead of an actor that had become nullptr by the time the function was being called).

- Apply the fix from this commit to all property and function nodes: https://github.com/DoubleDeez/MDFastBinding/commit/0d968a2d7c172bd1b366866394fbc1fed9f00f28
- Updated return value logic in `UMDFastBindingDestination_Property::GetPropertyOwner` to be symmetrical with `UMDFastBindingValue_Property::GetPropertyOwner`