### PR TITLE
CPU profiling trace updates

### DIFF
--- a/Source/MDFastBinding/MDFastBinding.Build.cs
+++ b/Source/MDFastBinding/MDFastBinding.Build.cs
@@ -27,5 +27,7 @@ public class MDFastBinding : ModuleRules
 				"SlateCore"
 			}
 		);
+		
+		PrivateDefinitions.Add("MDFASTBINDING_CONDENSED_PROFILING=0");
 	}
 }

--- a/Source/MDFastBinding/Private/BindingDestinations/MDFastBindingDestinationBase.cpp
+++ b/Source/MDFastBinding/Private/BindingDestinations/MDFastBindingDestinationBase.cpp
@@ -2,11 +2,17 @@
 
 #include "MDFastBindingInstance.h"
 #include "BindingValues/MDFastBindingValueBase.h"
+#include "Utils/MDFastBindingTraceHelpers.h"
 
 void UMDFastBindingDestinationBase::InitializeDestination(UObject* SourceObject)
 {
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING
+	MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(*GetName());
+#else
 	TRACE_CPUPROFILER_EVENT_SCOPE_STR(__FUNCTION__);
 	TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*GetName());
+#endif
+	
 	InitializeDestination_Internal(SourceObject);
 
 	for (const FMDFastBindingItem& BindingItem : BindingItems)
@@ -20,8 +26,13 @@ void UMDFastBindingDestinationBase::InitializeDestination(UObject* SourceObject)
 
 void UMDFastBindingDestinationBase::UpdateDestination(UObject* SourceObject)
 {
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING
+	MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(*GetName());
+#else
 	TRACE_CPUPROFILER_EVENT_SCOPE_STR(__FUNCTION__);
 	TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*GetName());
+#endif
+	
 	if (CheckCachedNeedsUpdate())
 	{
 		UpdateDestination_Internal(SourceObject);
@@ -30,8 +41,13 @@ void UMDFastBindingDestinationBase::UpdateDestination(UObject* SourceObject)
 
 void UMDFastBindingDestinationBase::TerminateDestination(UObject* SourceObject)
 {
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING
+	MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(*GetName());
+#else
 	TRACE_CPUPROFILER_EVENT_SCOPE_STR(__FUNCTION__);
 	TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*GetName());
+#endif
+	
 	TerminateDestination_Internal(SourceObject);
 
 	for (const FMDFastBindingItem& BindingItem : BindingItems)

--- a/Source/MDFastBinding/Private/BindingDestinations/MDFastBindingDestination_Function.cpp
+++ b/Source/MDFastBinding/Private/BindingDestinations/MDFastBindingDestination_Function.cpp
@@ -1,6 +1,7 @@
 ﻿#include "BindingDestinations/MDFastBindingDestination_Function.h"
 
 #include "MDFastBinding.h"
+#include "Utils/MDFastBindingTraceHelpers.h"
 
 #define LOCTEXT_NAMESPACE "MDFastBindingDestination_Function"
 
@@ -18,6 +19,13 @@ void UMDFastBindingDestination_Function::InitializeDestination_Internal(UObject*
 
 void UMDFastBindingDestination_Function::UpdateDestination_Internal(UObject* SourceObject)
 {
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING
+	MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(*Function.GetFunctionName().ToString());
+#else
+	TRACE_CPUPROFILER_EVENT_SCOPE_STR(__FUNCTION__);
+	TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*Function.GetFunctionName().ToString());
+#endif
+	
 	bNeedsUpdate = false;
 	Function.CallFunction(SourceObject);
 }

--- a/Source/MDFastBinding/Private/BindingValues/MDFastBindingValueBase.cpp
+++ b/Source/MDFastBinding/Private/BindingValues/MDFastBindingValueBase.cpp
@@ -41,8 +41,12 @@ void UMDFastBindingValueBase::TerminateValue(UObject* SourceObject)
 
 TTuple<const FProperty*, void*> UMDFastBindingValueBase::GetValue(UObject* SourceObject, bool& OutDidUpdate)
 {
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING
+	MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(*GetName());
+#else
 	TRACE_CPUPROFILER_EVENT_SCOPE_STR(__FUNCTION__);
 	TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*GetName());
+#endif
 
 	OutDidUpdate = false;
 

--- a/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Function.cpp
+++ b/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Function.cpp
@@ -2,6 +2,7 @@
 
 #include "MDFastBinding.h"
 #include "BindingDestinations/MDFastBindingDestinationBase.h"
+#include "Utils/MDFastBindingTraceHelpers.h"
 
 #define LOCTEXT_NAMESPACE "MDFastBindingDestination_Function"
 
@@ -18,6 +19,13 @@ UMDFastBindingValue_Function::UMDFastBindingValue_Function()
 
 TTuple<const FProperty*, void*> UMDFastBindingValue_Function::GetValue_Internal(UObject* SourceObject)
 {
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING
+	MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(*Function.GetFunctionName().ToString());
+#else
+	TRACE_CPUPROFILER_EVENT_SCOPE_STR(__FUNCTION__);
+	TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*Function.GetFunctionName().ToString());
+#endif
+	
 	bNeedsUpdate = false;
 	return Function.CallFunction(SourceObject);
 }

--- a/Source/MDFastBinding/Private/MDFastBindingContainer.cpp
+++ b/Source/MDFastBinding/Private/MDFastBindingContainer.cpp
@@ -1,13 +1,22 @@
 ﻿#include "MDFastBindingContainer.h"
+
 #include "MDFastBindingInstance.h"
 #include "MDFastBindingLog.h"
 #include "MDFastBindingOwnerInterface.h"
 #include "BindingDestinations/MDFastBindingDestinationBase.h"
 #include "Blueprint/UserWidget.h"
+#include "Utils/MDFastBindingTraceHelpers.h"
 #include "WidgetExtension/MDFastBindingWidgetExtension.h"
 
 void UMDFastBindingContainer::InitializeBindings(UObject* SourceObject)
 {
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING
+	MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(*GetNameSafe(SourceObject));
+#else
+	TRACE_CPUPROFILER_EVENT_SCOPE_STR(__FUNCTION__);
+	TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*GetNameSafe(SourceObject));
+#endif
+	
 	if (const UUserWidget* OuterWidget = Cast<UUserWidget>(GetOuter()))
 	{
 		UE_CLOG(!OuterWidget->IsDesignTime(), LogMDFastBinding, Warning, TEXT("[%s] uses a deprecated property-based MDFastBindingContainer, resave it to automatically upgrade it to a widget extension"), *GetNameSafe(OuterWidget->GetClass()));
@@ -27,8 +36,12 @@ void UMDFastBindingContainer::InitializeBindings(UObject* SourceObject)
 
 void UMDFastBindingContainer::UpdateBindings(UObject* SourceObject)
 {
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING
+	MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(*GetNameSafe(SourceObject));
+#else
 	TRACE_CPUPROFILER_EVENT_SCOPE_STR(__FUNCTION__);
 	TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*GetNameSafe(SourceObject));
+#endif
 
 	for (TConstSetBitIterator<> It(TickingBindings); It; ++It)
 	{
@@ -38,6 +51,13 @@ void UMDFastBindingContainer::UpdateBindings(UObject* SourceObject)
 
 void UMDFastBindingContainer::TerminateBindings(UObject* SourceObject)
 {
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING
+	MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(*GetNameSafe(SourceObject));
+#else
+	TRACE_CPUPROFILER_EVENT_SCOPE_STR(__FUNCTION__);
+	TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*GetNameSafe(SourceObject));
+#endif
+	
 	for (UMDFastBindingInstance* Binding : Bindings)
 	{
 		Binding->TerminateBinding(SourceObject);

--- a/Source/MDFastBinding/Private/MDFastBindingInstance.cpp
+++ b/Source/MDFastBinding/Private/MDFastBindingInstance.cpp
@@ -3,6 +3,7 @@
 #include "MDFastBindingContainer.h"
 #include "BindingDestinations/MDFastBindingDestinationBase.h"
 #include "BindingValues/MDFastBindingValueBase.h"
+#include "Utils/MDFastBindingTraceHelpers.h"
 
 #if WITH_EDITOR
 #include "UObject/ObjectSaveContext.h"
@@ -39,6 +40,13 @@ UMDFastBindingContainer* UMDFastBindingInstance::GetBindingContainer() const
 
 void UMDFastBindingInstance::InitializeBinding(UObject* SourceObject)
 {
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING && WITH_EDITORONLY_DATA
+	MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(*GetBindingDisplayName().ToString());
+#else
+	TRACE_CPUPROFILER_EVENT_SCOPE_STR(__FUNCTION__);
+	TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*GetBindingDisplayName().ToString());
+#endif
+	
 	if (BindingDestination != nullptr)
 	{
 		BindingDestination->InitializeDestination(SourceObject);
@@ -47,6 +55,13 @@ void UMDFastBindingInstance::InitializeBinding(UObject* SourceObject)
 
 bool UMDFastBindingInstance::UpdateBinding(UObject* SourceObject)
 {
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING && WITH_EDITORONLY_DATA
+	MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(*GetBindingDisplayName().ToString());
+#else
+	TRACE_CPUPROFILER_EVENT_SCOPE_STR(__FUNCTION__);
+	TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*GetBindingDisplayName().ToString());
+#endif
+	
 	if (BindingDestination != nullptr)
 	{
 		BindingDestination->UpdateDestination(SourceObject);
@@ -58,6 +73,13 @@ bool UMDFastBindingInstance::UpdateBinding(UObject* SourceObject)
 
 void UMDFastBindingInstance::TerminateBinding(UObject* SourceObject)
 {
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING && WITH_EDITORONLY_DATA
+	MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(*GetBindingDisplayName().ToString());
+#else
+	TRACE_CPUPROFILER_EVENT_SCOPE_STR(__FUNCTION__);
+	TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*GetBindingDisplayName().ToString());
+#endif
+	
 	if (BindingDestination != nullptr)
 	{
 		BindingDestination->TerminateDestination(SourceObject);

--- a/Source/MDFastBinding/Public/Utils/MDFastBindingTraceHelpers.h
+++ b/Source/MDFastBinding/Public/Utils/MDFastBindingTraceHelpers.h
@@ -1,0 +1,12 @@
+// 1047 Custom - Enhance MDFastBinding profiling readability
+#pragma once
+
+#include "ProfilingDebugging/CpuProfilerTrace.h"
+
+#if defined(MDFASTBINDING_CONDENSED_PROFILING) && MDFASTBINDING_CONDENSED_PROFILING
+
+// Trace a scoped cpu timing event providing the current function along with specified text appended to it
+// Note: This macro has a larger overhead compared to TRACE_CPUPROFILER_EVENT_SCOPE_TEXT()
+#define MD_TRACE_CPUPROFILER_EVENT_SCOPE_FUNCTION_TEXT(Text) TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*FString::Printf(TEXT("%s - %s"), ANSI_TO_TCHAR(__FUNCTION__), Text));
+
+#endif


### PR DESCRIPTION
- Increased profiling trace coverage, notably with regards to function nodes
- Added a `MDFASTBINDING_CONDENSED_PROFILING` directive to allow for a more 'compact' view of the trace events in the timeline (at the expense of some CPU cycles)

Note that `MDFASTBINDING_CONDENSED_PROFILING` is disabled by default to maintain existing behavior, but it has helped reduce a lot of clutter and depth in the timeline graph. I'll leave it up to you on whether it's worth enabling by default (at the expense of the trace's absolute performance cost).