### PR TITLE
Configurable default UpdateType

### DIFF
--- a/Config/BaseMDFastBinding.ini
+++ b/Config/BaseMDFastBinding.ini
@@ -1,2 +1,10 @@
 [CoreRedirects]
 +ClassRedirects=(OldName="/Script/MDFastBindingEditor.MDFastBindingWidgetBlueprintExtension",NewName="/Script/MDFastBindingBlueprint.MDFastBindingWidgetBlueprintExtension")
+
+[/Script/MDFastBinding.MDFastBindingValue_Property]
+; Make the default match UMG Binding behaviour since the property value could have changed
+UpdateType=Always
+
+[/Script/MDFastBinding.MDFastBindingValue_Function]
+; Make the default case more 'correct' since a function _could_ return different results given the same inputs
+UpdateType=Always

--- a/Config/DefaultMDFastBinding.ini
+++ b/Config/DefaultMDFastBinding.ini
@@ -1,2 +1,10 @@
 [CoreRedirects]
 +ClassRedirects=(OldName="/Script/MDFastBindingEditor.MDFastBindingWidgetBlueprintExtension",NewName="/Script/MDFastBindingBlueprint.MDFastBindingWidgetBlueprintExtension")
+
+[/Script/MDFastBinding.MDFastBindingValue_Property]
+; Make the default match UMG Binding behaviour since the property value could have changed
+UpdateType=Always
+
+[/Script/MDFastBinding.MDFastBindingValue_Function]
+; Make the default case more 'correct' since a function _could_ return different results given the same inputs
+UpdateType=Always

--- a/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_FieldNotify.cpp
+++ b/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_FieldNotify.cpp
@@ -9,7 +9,6 @@
 
 UMDFastBindingValue_FieldNotify::UMDFastBindingValue_FieldNotify()
 {
-	UpdateType = EMDFastBindingUpdateType::EventBased;
 	PropertyPath.bAllowGetterFunctions = true;
 	PropertyPath.bAllowSubProperties = false;
 }
@@ -19,6 +18,9 @@ void UMDFastBindingValue_FieldNotify::PostInitProperties()
 	PropertyPath.FieldFilter.BindUObject(this, &UMDFastBindingValue_FieldNotify::IsValidFieldNotify);
 
 	Super::PostInitProperties();
+
+	// Don't let config overwrite our UpdateType
+	UpdateType = EMDFastBindingUpdateType::EventBased;
 }
 
 #if WITH_EDITOR

--- a/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Function.cpp
+++ b/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Function.cpp
@@ -12,8 +12,7 @@ namespace MDFastBindingValue_Function_Private
 
 UMDFastBindingValue_Function::UMDFastBindingValue_Function()
 {
-	// Make the default case more 'correct' since a function _could_ return different results given the same inputs
-	UpdateType = EMDFastBindingUpdateType::Always;
+
 }
 
 TTuple<const FProperty*, void*> UMDFastBindingValue_Function::GetValue_Internal(UObject* SourceObject)

--- a/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Property.cpp
+++ b/Source/MDFastBinding/Private/BindingValues/MDFastBindingValue_Property.cpp
@@ -11,8 +11,7 @@ namespace MDFastBindingValue_Property_Private
 
 UMDFastBindingValue_Property::UMDFastBindingValue_Property()
 {
-	// Make the default match UMG Binding behaviour since the property value could have changed
-	UpdateType = EMDFastBindingUpdateType::Always;
+
 }
 
 TTuple<const FProperty*, void*> UMDFastBindingValue_Property::GetValue_Internal(UObject* SourceObject)

--- a/Source/MDFastBinding/Public/MDFastBindingObject.h
+++ b/Source/MDFastBinding/Public/MDFastBindingObject.h
@@ -113,7 +113,7 @@ private:
 /**
  *
  */
-UCLASS()
+UCLASS(Config="MDFastBinding")
 class MDFASTBINDING_API UMDFastBindingObject : public UObject
 {
 	GENERATED_BODY()
@@ -232,7 +232,7 @@ protected:
 	int32 ExtendablePinListCount = 0;
 
 	// Values are cached, this setting determines when to grab a new value or use the cached value
-	UPROPERTY(EditAnywhere, Category = "Performance")
+	UPROPERTY(EditAnywhere, Config, Category = "Performance")
 	EMDFastBindingUpdateType UpdateType = EMDFastBindingUpdateType::IfUpdatesNeeded;
 
 private:


### PR DESCRIPTION
This PR makes the default value for UpdateType configurable via ini files.

FieldNotify ignores this config and forces EventBased, since that is the only update type that makes sense for it.